### PR TITLE
Greyed out countries and changes to colour space

### DIFF
--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -36,7 +36,7 @@ export default function WorldMap() {
     // c.color = c.alpha3 == selected ? "red" : "green"; 
     if (raw_value == null) return null;
     const selectedValue = (selected != null ? get_country_value(selected, category) : 0);
-    const relative_value = (raw_value - selectedValue) / country_values_range(category, selected == null);
+    const relative_value = (raw_value - selectedValue) / (selected != null ? country_values_range(category, false) : 1);
     const extreme_color = relative_value > 0 ? "red" : "green";
     //between 0 and 1. 0 is white (=similar to selected), 1 is extreme_color (=not similar to selected)
     const absolute_value = Math.abs(relative_value);

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -29,16 +29,19 @@ export default function WorldMap() {
   const [category, setCategory] = useState(0);
   const svgRef = useRef()
 
+    if (selected != null) console.log(get_country_value(selected, category));
+
   function valToColor(raw_value, alpha3_for_reference) {
     //value is as in the original data set.
     // c.color = c.alpha3 == selected ? "red" : "green"; 
-    const selectedValue = get_country_value(selected, category);
-    const relative_value = (raw_value - selectedValue) / country_values_range(category);
+    if (raw_value == null) return null;
+    const selectedValue = (selected != null ? get_country_value(selected, category) : 0);
+    const relative_value = (raw_value - selectedValue) / country_values_range(category, selected == null);
     const extreme_color = relative_value > 0 ? "red" : "green";
     //between 0 and 1. 0 is white (=similar to selected), 1 is extreme_color (=not similar to selected)
     const absolute_value = Math.abs(relative_value);
     return interpolateRgb("white", extreme_color)(absolute_value).toString();
-  }
+    }
   const mapData = parseJSON();
   if (!mapData) {
     return <pre>Loading...</pre>;

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -29,8 +29,6 @@ export default function WorldMap() {
   const [category, setCategory] = useState(0);
   const svgRef = useRef()
 
-    if (selected != null) console.log(get_country_value(selected, category));
-
   function valToColor(raw_value, alpha3_for_reference) {
     //value is as in the original data set.
     // c.color = c.alpha3 == selected ? "red" : "green"; 

--- a/src/features/WorldMap/lineDraw.jsx
+++ b/src/features/WorldMap/lineDraw.jsx
@@ -67,7 +67,7 @@ export function LineDraw({
                 {
                     (hovered != null) ?
                         (
-                        <path hoveredCountry
+                        <path
                                 key="hovered"
                                 id={iso_countries.find(c => c.alpha3 === hovered).alpha3}
                                 fill={iso_countries.find(c => c.alpha3 === hovered).color}

--- a/src/features/WorldMap/lineDraw.jsx
+++ b/src/features/WorldMap/lineDraw.jsx
@@ -10,17 +10,17 @@ const graticule = geoGraticule();
 export function LineDraw({
   data: { iso_countries, non_iso_countries, interiorBorders }, selectCountry,selected,hovered, setHovered,svgRef
 }) {
-  const gRef = useRef()
-  const legendRef = useRef()
-  useEffect(()=>{
-    if (svgRef && gRef) {
-      const svg = select(svgRef.current)
-      const g = select(gRef.current)
-      svg.call(zoom().on('zoom', (event) => {
-        g.attr('transform', event.transform);
-      }))
-  }
-  }, [])
+        const gRef = useRef()
+        const legendRef = useRef()
+        useEffect(()=>{
+            if (svgRef && gRef) {
+                const svg = select(svgRef.current)
+                const g = select(gRef.current)
+                svg.call(zoom().on('zoom', (event) => {
+                g.attr('transform', event.transform);
+            }))
+        }
+    }, [])
     return (
         <>
         <g className="mark" ref={gRef}>
@@ -43,11 +43,12 @@ export function LineDraw({
                           <path
                               key={c.alpha3}
                               id={c.alpha3}
-                              fill={c.color}
+                              fill={c.color != null ? c.color : "#555"}
                               className="country"
                               d={path(c.geometry)}
                               onMouseOver={() => {
-                                  setHovered(c.alpha3);
+                                  if (c.color != null) setHovered(c.alpha3);
+                                  else setHovered(null);
                               }}
                           />
                       ))
@@ -78,7 +79,6 @@ export function LineDraw({
                                 onClick={(e) => {
                                     setHovered(null);
                                     selectCountry(e.target.id);
-                                    
                                 }}
                         />
                         ) : ""

--- a/src/model/dumbDataHandler.jsx
+++ b/src/model/dumbDataHandler.jsx
@@ -1065,8 +1065,9 @@ export function get_country_value(alpha3, cathegory_index) {
 
 //difference between the highest and lowest value for each cathegory
 var values_range = [null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null];
-export function country_values_range(cathegory_index) {
-    if (values_range[cathegory_index] !== null) return values_range[cathegory_index];
+export function country_values_range(cathegory_index, zeroBased) {
+    const baseIndex = zeroBased ? 1 : 0
+    if (values_range[cathegory_index] !== null) return values_range[cathegory_index][baseIndex];
 
     let min = 1;
     let max = -1;
@@ -1075,9 +1076,7 @@ export function country_values_range(cathegory_index) {
         if (value < min) min = value;
         if (value > max) max = value;
     }
-    values_range[cathegory_index] = max - min;
+    values_range[cathegory_index] = [max - min, Math.max(Math.abs(min), Math.abs(max))];
     console.log(values_range)
-    return values_range[cathegory_index];
-
-
+    return values_range[cathegory_index][baseIndex];
 }


### PR DESCRIPTION
Greys out countries that do not have any data.

Also, the color space was previously always based on the range of our values. This was problematic when no country was selected since the base value is zero in that case. For example, if the range was 0.5 - 0.7 and no country was selected everything would appear to be completely red without any shading since the colour space would be values (-0.1) - 0.1 which does not contain the value space. Now the colour space would be (-0.7) - 0.7 in order to show how every country relates to 0.