### PR TITLE
Makes the line width respond to zoom

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ function App() {
   return (
     <div className="vh-100 w-100" style={{minHeight: '100vh', maxHeight: '100vh'}}>
       <TabSwitch>
-        <WorldMap icon="" title="PerCathegoryViz"/>
+        <WorldMap icon="" title="PerCategoryViz"/>
         <div icon="" title="RelativeToCountryViz">Hello</div>
         <AboutTab icon="" title="About"/>
       </TabSwitch>

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -25,6 +25,7 @@ export default function WorldMap() {
   //currently selected country (alpha3)
   const [selected, setSelected] = useState(null);
   const [hovered, setHovered] = useState(null);
+   const [zoomLevel, zoomLevelSetter] = useState(null);
   //TODO interactive cathegory selection. (cathegory index)
   const [category, setCategory] = useState(0);
   const svgRef = useRef()
@@ -48,7 +49,7 @@ export default function WorldMap() {
       <svg width={canvasWidth} height={canvasHeight} ref={svgRef} onMouseLeave={() => { setHovered(null) } }>
           <LineDraw
               data={{ ...mapData, iso_countries: mapData.iso_countries.map(c => ({ ...c, color: valToColor(get_country_value(c.alpha3, category), c.alpha3) })) }}
-              selectCountry={setSelected} selected={selected} hovered={hovered} setHovered={setHovered} svgRef={svgRef}
+              selectCountry={setSelected} selected={selected} hovered={hovered} setHovered={setHovered} zoomLevel={zoomLevel} zoomLevelSetter={zoomLevelSetter} svgRef={svgRef}
       />
     </svg>
   );

--- a/src/features/WorldMap/lineDraw.jsx
+++ b/src/features/WorldMap/lineDraw.jsx
@@ -7,8 +7,13 @@ const projection = geoNaturalEarth1();
 const path = geoPath(projection);
 const graticule = geoGraticule();
 
+const selectedLineWidth = 1;
+const hoveredLineWidth = 1.3;
+const borderLineWidth = 0.5;
+const zoomLineStrength = 0.5;
+
 export function LineDraw({
-  data: { iso_countries, non_iso_countries, interiorBorders }, selectCountry,selected,hovered, setHovered,svgRef
+    data: { iso_countries, non_iso_countries, interiorBorders }, selectCountry, selected, hovered, setHovered, zoomLevel, zoomLevelSetter, svgRef
 }) {
         const gRef = useRef()
         const legendRef = useRef()
@@ -18,6 +23,7 @@ export function LineDraw({
                 const g = select(gRef.current)
                 svg.call(zoom().on('zoom', (event) => {
                 g.attr('transform', event.transform);
+                zoomLevelSetter(Math.max(event.transform.k, 1));
             }))
         }
     }, [])
@@ -62,16 +68,17 @@ export function LineDraw({
                 d={path(c.geometry)}
               />
             ))
-            }
-            <path className="interiorBorders" d={path(interiorBorders)} />
+                }
+                <path className="interiorBorders" d={path(interiorBorders)} strokeWidth={` ${borderLineWidth * (1 / (zoomLevel * zoomLineStrength))}px`} />
                 {
                     (hovered != null) ?
                         (
-                        <path
+                            <path
                                 key="hovered"
                                 id={iso_countries.find(c => c.alpha3 === hovered).alpha3}
                                 fill={iso_countries.find(c => c.alpha3 === hovered).color}
                                 className="hoveredCountry"
+                                strokeWidth={` ${hoveredLineWidth * (1 / (zoomLevel * zoomLineStrength))}px`}
                                 d={path(iso_countries.find(c => c.alpha3 === hovered).geometry)}
                                 onMouseLeave={() => {
                                     setHovered(null);
@@ -88,7 +95,8 @@ export function LineDraw({
                 <path
                     key={"selected"}
                     id="selectedCountryBorder"
-                    fill="none"
+                                fill="none"
+                                strokeWidth={` ${selectedLineWidth * (1 / (zoomLevel * zoomLineStrength))}px`}
                     className="selectedCountry"
                     d={path(iso_countries.find(c => c.alpha3 === selected).geometry)}
                 />

--- a/src/worldMap.css
+++ b/src/worldMap.css
@@ -1,6 +1,5 @@
 .mark .selectedCountry {
 	stroke: #cc0000;
-	stroke-width: 1.1px;
 }
 
 #WorldCanvasDiv {
@@ -8,18 +7,15 @@
 }
 .mark .selectedCountry {
 	stroke: #cc0000;
-	stroke-width: 1px;
 }
 
 .mark .hoveredCountry { 
   stroke: #36c94d;
-  stroke-width: 1.6px;
 }
 
 .mark .interiorBorders {
   fill: none;
   stroke: #1d1d1d67;
-  stroke-width: 0.5px;
 }
 
 .mark .earthSphere {


### PR DESCRIPTION
The width of the country borders, selected line and hover line are all now dependant on the level of zoom. This makes the map look a lot more clean when zoomed in. Also fixes a spelling error in the tabs "PerCategoryViz" -> "PerCategoryViz".

Edit:
To clarify, zooming in makes the lines less thick.