### PR TITLE
Deleted countries Réunion (REU) and Martinique (MTQ)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,20 @@ function App() {
     }
     window.addEventListener('resize', handleResize);
     fetch_data().then((data) => {
+      /* MTQ (Martinique), REU (Réunion) --> Two french departments
+        These countries have separate keys in CountriesChangePr.json
+        But in the topoJson map data they're in the same path-data as France.
+        
+        In Species: pets vs. humans, at least one of them was the most human-friendly, so
+        when brushing no country was "visible".
+
+        Solutions:
+        1. Separate the path data from France, i.e give them unique paths (TIME CONSUMING???)
+        2. Aggregate MTQ and REU's ansers to France (HOW???)
+        --> 3. Delete the countries from the data and write a disclaimer (EASIEST) 
+      */
+        delete data.json_data.countries.MTQ
+        delete data.json_data.countries.REU
       setData(data);
       parseJSON(data).then((map) => setMap(map)) //needs to be called after data is set
     });

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -45,6 +45,8 @@ export default function WorldMap({data, map, isActiveTab}) {
   const categoryStatistics = data.country_values_stats(category.id)
   const range = getRange(selected, category, categoryStatistics)
 
+  console.log('Countries:', Object.values(map.iso_countries).filter((c) => c?.hasData && isInRange(c[category.id], brushRange)))
+
   function valueToColor(value, colorForLegend=false) {
     if (!value)
       return colorScheme.noData;

--- a/src/utils/parseMapJSON.jsx
+++ b/src/utils/parseMapJSON.jsx
@@ -1,4 +1,3 @@
-import React, { useState, useCallback, useEffect } from "react";
 import { json } from "d3";
 import { feature } from "topojson-client";
 import iso from "iso-3166-1";
@@ -9,31 +8,53 @@ const mapJSON = "https://unpkg.com/world-atlas@2.0.2/countries-50m.json";
 //will only be executed once (App useEffect)
 export async function parseJSON(data) {
     return json(mapJSON).then((jsonData) => {
-        //console.log(jsonData);
         const { features } = feature(jsonData, jsonData.objects.countries);
+
+        let ashmoreAndCartier = null
     //[{ "alpha3": "FJI", "name": "Fiji", "geometry": {"type": "MultiPolygon","coordinates": [[[[100,-10]]]] }]
-    //console.log("hi!")
     const iso_countries = features
       .filter((d) => d.id !== undefined)
       .reduce((acc, d) => {
         const alpha3 = iso.whereNumeric(d.id).alpha3;
         const country_data = data.get_country_data(alpha3);
-        acc[alpha3] = {
-          // The country data already includes a field named "id". Therefore, we do not add "alpha3" too.
-          ...country_data,
-          // If the country has no data, data is null. Therefore we have to write the id again.
-          id: alpha3,
-          hasData: !!country_data,
-          name: d.properties.name,
-          geometry: d.geometry,
-        };
+        // if (d.id === '036') { console.log(d, '------', iso.whereNumeric(d.id).alpha3)}
+        if (alpha3 in acc) { 
+          // Ashmore And Acartier has the same country code as Austrlia (AUS)
+          //console.log('First added key - key: ', alpha3, ', element: ',acc[alpha3], ' Duplicate: key: ', alpha3, ' element: ', d)
+          ashmoreAndCartier = { name: d.properties.name, geometry: d.geometry }
+        } else {
+          acc[alpha3] = {
+            // The country data already includes a field named "id". Therefore, we do not add "alpha3" too.
+            ...country_data,
+            // If the country has no data, data is null. Therefore we have to write the id again.
+            id: alpha3,
+            hasData: !!country_data,
+            name: d.properties.name,
+            geometry: d.geometry,
+          };
+        }
+    
         return acc;
       }, {});
+      // console.log('FEATURES: ', features.length)
+
 
     //[{ "name": "Fiji", "geometry": {"type": "MultiPolygon","coordinates": [[[[100,-10]]]] }]
     const non_iso_countries = features
       .filter((d) => d.id === undefined)
       .map((d) => ({ name: d.properties.name, geometry: d.geometry }));
+
+
+    if (ashmoreAndCartier) non_iso_countries.push(ashmoreAndCartier)
+    // console.log('iso_countries: ', Object.keys(iso_countries).length)
+    // console.log('non_iso_countries: ', non_iso_countries.length)
+    /* 
+    Object.values(data.json_data.countries).forEach((c) => {
+      if (!Object.keys(iso_countries).includes(c.id)) {
+        console.log(c)
+      }
+    })
+    */ 
     return {
       iso_countries,
       non_iso_countries,


### PR DESCRIPTION
Deleted countries Réunion (REU) and Martinique (MTQ) which had their own answers but are part of France in the topojson data. Also, Ashmore And Cartier have the same country code as Australia (AUS), which led to Ashmore And Cartier's path (tiny island) replacing Australia's path --> Australia disappeared. This is solved here.