### PR TITLE
Makes it so that hovering is not marked on the cluster map

### DIFF
--- a/src/features/Cluster/Cluster.jsx
+++ b/src/features/Cluster/Cluster.jsx
@@ -146,7 +146,8 @@ export default function Cluster({clusterData, map, isActiveTab}) {
                 selected={selected}
                 setSelected={setSelected}
                 hovered={hovered}
-                setHovered={setHovered}
+                  setHovered={setHovered}
+                  hoverable={ false }
                 zoomLevel={zoomLevel}
                 setZoomLevel={setZoomLevel}
                 doResetZoom={doResetZoom}
@@ -199,7 +200,6 @@ export default function Cluster({clusterData, map, isActiveTab}) {
               </div>
             </div>
           </div>
-
         </div>
       </div>  
 

--- a/src/features/CountryDistance/CountryDistance.jsx
+++ b/src/features/CountryDistance/CountryDistance.jsx
@@ -97,6 +97,7 @@ export default function CountryDistance({ data, map, isActiveTab }) {
             setSelected={setSelected}
             hovered={hovered}
             setHovered={setHovered}
+            hoverable={true}
             zoomLevel={zoomLevel}
             setZoomLevel={setZoomLevel}
             doResetZoom={doResetZoom}

--- a/src/features/HomePage/HomePage.jsx
+++ b/src/features/HomePage/HomePage.jsx
@@ -5,7 +5,7 @@ export default function HomePage({setActiveTabNumber}){
     <div className="d-flex flex-grow-1 flex-column align-items-center">
       <div className="w-75 d-flex flex-column align-items-center pt-5">
         <p className="fs-1">The moral machine map</p>
-        <p>This app is a visual representation of the data gathered by the &nbsp;
+        <p>This app is a visual representation of the data gathered by the&nbsp;
           <a href='https://www.moralmachine.net/'>Moral Machine project.</a></p>
         <p className="fs-4">Moral Machine project</p>
         <p>

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -85,6 +85,7 @@ export default function WorldMap({data, map, isActiveTab}) {
                 setSelected={setSelected}
                 hovered={hovered}
                 setHovered={setHovered}
+                hoverable={true}
                 zoomLevel={zoomLevel}
                 setZoomLevel={setZoomLevel}
                 doResetZoom={doResetZoom}

--- a/src/features/WorldMap/WorldMap.jsx
+++ b/src/features/WorldMap/WorldMap.jsx
@@ -41,7 +41,7 @@ export default function WorldMap({data, map, isActiveTab}) {
   const categoryStatistics = data.country_values_stats(category.id)
   const range = getRange(selected, category, categoryStatistics)
 
-  console.log('Countries:', Object.values(map.iso_countries).filter((c) => c?.hasData && isInRange(c[category.id], brushRange)))
+  //console.log('Countries:', Object.values(map.iso_countries).filter((c) => c?.hasData && isInRange(c[category.id], brushRange)))
 
   function valueToColor(value, colorForLegend=false) {
     if (!value)

--- a/src/utils/lineDraw.jsx
+++ b/src/utils/lineDraw.jsx
@@ -18,8 +18,9 @@ class svgHandler {
   svg; //svg dom element: the world map.
   non_iso_countries_paths; //paths for non-iso countries
   selected_path; //path for selected country
+  hoverable; //Keeps track of if the map should be hoverable
 
-  //since JSX elements are immutable, we have to rebuild the whole tree.
+    //since JSX elements are immutable, we have to rebuild the whole tree.
   //this method is executed on rerender.
   //TODO: move as much as possible to constructor. (building of paths, ...)
   colorize = (countryToColor, selected) => {
@@ -95,6 +96,7 @@ class svgHandler {
     ];
     this.hover_paths =
       //example country: {"color": "#040", "id": "FJI", "geometry": {"type": "MultiPolygon","coordinates": [[[[100,-10]...]]]
+        (this.hoverable ?
       Object.values(this.iso_countries)
         .filter((c) => c.hasData)
         .map((c) => {
@@ -111,8 +113,7 @@ class svgHandler {
               setSelected(iso_countries[e.target.id]);
             }}
           />
-          
-        )});
+        )}) : "");
     this.selected_path = selected && (
       <path
         vectorEffect="non-scaling-stroke"
@@ -135,7 +136,7 @@ class svgHandler {
     );
   };
 
-  constructor(iso_countries, non_iso_countries, gRef, path, setSelected) {
+    constructor(iso_countries, non_iso_countries, gRef, path, setSelected, hoverable) {
     this.gRef = gRef;
     
     //path is "consumed" here.
@@ -145,6 +146,7 @@ class svgHandler {
     this.non_iso_countries = non_iso_countries;
     this.setSelected = setSelected;
     this.svg = "";
+        this.hoverable = hoverable;
 
 
     //path:
@@ -169,6 +171,7 @@ export function LineDraw({
   selected,
   setSelected,
   zoomLevel,
+  hoverable,
   setZoomLevel,
   doResetZoom,
   setDoResetZoom,
@@ -200,7 +203,7 @@ export function LineDraw({
   //of course we are very efficcient and only generate the whole SVG thing once :)
   const [svg_handler, _] = React.useState(
     () =>
-      new svgHandler(iso_countries, non_iso_countries, gRef, path, setSelected)
+          new svgHandler(iso_countries, non_iso_countries, gRef, path, setSelected, hoverable)
   );
 
   function ZoomCall() {


### PR DESCRIPTION
Makes it so that hovering is not marked on the cluster map. This was done because we got feedback from the big man himself earlier stating that it was confusing that the map was hoverable even though there was no functionality when things were clicked.

(This should also slightly increase the performance on that map since it no longer draws the layer of hover markers).